### PR TITLE
[#2] Fix to delete simulator on key press `command+delete`

### DIFF
--- a/SimBatchDelete/ViewController.swift
+++ b/SimBatchDelete/ViewController.swift
@@ -3,6 +3,12 @@
 //
 
 import Cocoa
+import IOKit
+
+// for maintaining key code for keyboard entry.
+enum KeyCodes {
+    static let delete: UInt16 = 0x33
+}
 
 struct SimViewModel {
 
@@ -193,10 +199,12 @@ extension ViewController: NSTableViewDelegate {
     }
     
     override func keyDown(with event: NSEvent) {
-        guard event.keyCode == 51 else {
-            return
+        switch event.modifierFlags.intersection(.deviceIndependentFlagsMask) {
+        case [.command] where event.keyCode == KeyCodes.delete:
+            self.deleteCurrenltySelectedSimulator()
+        default:
+            break
         }
-        self.deleteCurrenltySelectedSimulator()
     }
     
 }

--- a/SimBatchDelete/ViewController.swift
+++ b/SimBatchDelete/ViewController.swift
@@ -95,27 +95,7 @@ class ViewController: NSViewController {
     }
 
     @IBAction private func deleteSelectedDevices(_ sender: NSButton) {
-        let simsToDelete = self.selectedSims
-        self.selectedSims.removeAll()
-
-        var simsToDeleteCount = simsToDelete.count
-        for sim in simsToDelete.values {
-            self.parser.deleteDevice(sim.identifier) { [weak self] result in
-                DispatchQueue.main.async {
-                    simsToDeleteCount -= 1
-                    switch result {
-                    case .success:
-                        print("\(sim.name) delete successful")
-                    case .failure(let err):
-                        print("\(sim.name) deletion error: \(err)")
-                    }
-
-                    if (simsToDeleteCount <= 0) {
-                        self?.reloadData()
-                    }
-                }
-            }
-        }
+        self.deleteAllCheckboxedSimulators()
     }
 
     private func reloadData() {
@@ -211,5 +191,57 @@ extension ViewController: NSTableViewDelegate {
 
         return cell
     }
+    
+    override func keyDown(with event: NSEvent) {
+        guard event.keyCode == 51 else {
+            return
+        }
+        self.deleteCurrenltySelectedSimulator()
+    }
+    
+}
+
+extension ViewController {
+    private func deleteAllCheckboxedSimulators() {
+        let simsToDelete = self.selectedSims
+        self.selectedSims.removeAll()
+        var simsToDeleteCount = simsToDelete.count
+        for sim in simsToDelete.values {
+            self.parser.deleteDevice(sim.identifier) { [weak self] result in
+                DispatchQueue.main.async {
+                    simsToDeleteCount -= 1
+                    switch result {
+                    case .success:
+                        print("\(sim.name) delete successful")
+                    case .failure(let err):
+                        print("\(sim.name) deletion error: \(err)")
+                    }
+                    if (simsToDeleteCount <= 0) {
+                        self?.reloadData()
+                    }
+                }
+            }
+        }
+    }
+    
+    private func deleteCurrenltySelectedSimulator() {
+        let selectedRowIndex = self.tableView.selectedRow
+        guard selectedRowIndex <= self.simulators.count else {
+            return
+        }
+        let simulator = self.simulators[selectedRowIndex]
+        self.parser.deleteDevice(simulator.identifier) { [weak self] result in
+            DispatchQueue.main.async {
+                switch result {
+                case .success:
+                    print("\(simulator.name) delete successful")
+                case .failure(let err):
+                    print("\(simulator.name) deletion error: \(err)")
+                }
+                self?.reloadData()
+            }
+        }
+    }
+
 }
 


### PR DESCRIPTION
## Preview
<img width="783" alt="Screenshot 2019-10-12 at 2 54 18 AM" src="https://user-images.githubusercontent.com/24624646/66685989-9aa37380-ec9b-11e9-9fa8-d680438cd265.png">

## What and How
Allow the deletion of a single selected row. Delete simulator on command+delete Keypress.

## Why 
In order to be able to delete the currently selected simulator on command+delete Keypress.

## References
#2 
